### PR TITLE
Fix for 10.10 WebKit2

### DIFF
--- a/SafariStand/ClipWebArchive/HTWebClipwinCtl.m
+++ b/SafariStand/ClipWebArchive/HTWebClipwinCtl.m
@@ -40,6 +40,21 @@ title=>title
     NSString* _filePath;
 }
 
+void showWindowForFrontmostWKViewGetWebArchive(WKDataRef archiveData, WKErrorRef error, void* info)
+{
+        if (archiveData) {
+                NSDictionary* dic=(__bridge NSDictionary*)info;
+                NSData* data=htNSDataFromWKData(archiveData);
+                WebArchive* arc=[[WebArchive alloc]initWithData:data];
+
+                [HTWebClipwinCtl showWindowForWebArchive:arc webFrame:nil info:dic];
+
+                //WKRelease(archiveData);
+            }
+        if (info) {
+                CFRelease(info);
+            }
+    }
 
 + (void)showUntitledWindow
 {
@@ -71,18 +86,8 @@ title=>title
     WKPageRef pageRef=htWKPageRefForWKView(wkView);
     if (pageRef) {
         WKFrameRef frameRef=WKPageGetMainFrame(pageRef);
-        
-        WKFrameGetWebArchive_b(frameRef, ^(WKDataRef archiveData, WKErrorRef error){
-            if (archiveData) {
-                NSDictionary* dic=info;
-                NSData* data=htNSDataFromWKData(archiveData);
-                WebArchive* arc=[[WebArchive alloc]initWithData:data];
-                
-                [HTWebClipwinCtl showWindowForWebArchive:arc webFrame:nil info:dic];
-                
-                //WKRelease(archiveData);
-            }
-        });
+        WKFrameGetWebArchive(frameRef, showWindowForFrontmostWKViewGetWebArchive, (void*)CFBridgingRetain(info));
+
     }
 }
 

--- a/SafariStand/util/HTWebKit2Adapter.h
+++ b/SafariStand/util/HTWebKit2Adapter.h
@@ -120,8 +120,6 @@ extern void WKFrameGetResourceData(WKFrameRef frame, WKURLRef resourceURL, WKFra
 
 typedef void (*WKFrameGetWebArchiveFunction)(WKDataRef archiveData, WKErrorRef error, void* functionContext);
 extern void WKFrameGetWebArchive(WKFrameRef frame, WKFrameGetWebArchiveFunction function, void* functionContext);
-typedef void (^WKFrameGetWebArchiveBlock)(WKDataRef archiveData, WKErrorRef error);
-extern void WKFrameGetWebArchive_b(WKFrameRef frame, WKFrameGetWebArchiveBlock block);
 
 extern WKFrameRef WKPageGetMainFrame(WKPageRef page);
 


### PR DESCRIPTION
Don't use block-based API.
Removed in https://trac.webkit.org/changeset/159059
