### PR TITLE
Fix duplicate tab favicons on pinned tabs

### DIFF
--- a/SafariStand/modules/STSTabBarModule.m
+++ b/SafariStand/modules/STSTabBarModule.m
@@ -223,6 +223,10 @@
         return;
     }
 
+    if([[tabViewItem valueForKey:@"pinned"] boolValue]) {
+        return;
+    }
+
     NSView* closeButton=[tabButton valueForKey:@"_closeButton"];
     if (!closeButton) {
         return;


### PR DESCRIPTION
This fixes https://github.com/hetima/SafariStand/issues/45 by disabling favicons for pinned tabs.

Some people might want to replace them instead, but this would require additional logic to disable the Safari-provided icons.
